### PR TITLE
Add CLI tool for extracting and decompressing PMD2 pack files

### DIFF
--- a/tools/extract_pack.py
+++ b/tools/extract_pack.py
@@ -1,9 +1,83 @@
 """A tool to extract sub-files from a PMD2 pack file."""
 
+from collections import deque
 from pathlib import Path
 
 import click
+from kaitaistruct import KaitaiStructError
+from pkdpx import Pkdpx
 from pmd2pack import Pmd2pack
+
+
+def decompress(data: bytes, control_flags: bytes) -> bytes:
+    """Decompress PKDPX files which use PMD2 PX compression."""
+
+    in_queue = deque(data)
+    out = []
+
+    while in_queue:
+        command_byte = in_queue.popleft()
+        mask = 0x80
+
+        while mask > 0:
+            if not in_queue:
+                break
+
+            bitval = command_byte & mask
+            mask >>= 1
+
+            if bitval:
+                # Copy next byte.
+                out.append(in_queue.popleft())
+
+            else:
+                # Process next byte.
+                byte = in_queue.popleft()
+                nbhigh = (byte >> 4) & 0xF
+                nblow = byte & 0xF
+
+                if nbhigh in control_flags:
+                    ctrlflagindex = control_flags.index(nbhigh)
+
+                    if ctrlflagindex == 0:
+                        # Insert byte pattern.
+                        byte1 = (nblow << 4) | nblow
+                        byte2 = byte1
+                        out.extend([byte1, byte2])
+                    else:
+                        # Insert special byte pattern.
+                        basenybbleval = nblow
+                        if ctrlflagindex == 1:
+                            basenybbleval += 1
+                        elif ctrlflagindex == 5:
+                            basenybbleval -= 1
+
+                        nybbles = [basenybbleval] * 4
+
+                        if 1 <= ctrlflagindex <= 4:
+                            nybbles[ctrlflagindex - 1] -= 1
+                        else:
+                            nybbles[ctrlflagindex - 5] += 1
+
+                        byte1 = (nybbles[0] << 4) | nybbles[1]
+                        byte2 = (nybbles[2] << 4) | nybbles[3]
+                        out.extend([byte1, byte2])
+
+                else:
+                    # Copy sequence.
+                    if not in_queue:
+                        break
+                    offset_byte = in_queue.popleft()
+                    offset = ((nblow << 8) | offset_byte) - 0x1000
+                    seqbeg = len(out) + offset
+
+                    length = nbhigh + 3
+
+                    for i in range(length):
+                        src_index = seqbeg + i
+                        out.append(out[src_index])
+
+    return bytes(out)
 
 
 @click.command()
@@ -18,7 +92,13 @@ def main(pack_file: str, output_dir: str) -> None:
 
     file: Pmd2pack.File
     for i, file in enumerate(pack.files):
-        open(extract_path / str(i), "wb").write(file.data)
+        try:
+            pkdpx = Pkdpx.from_bytes(file.data)
+            output_data = decompress(pkdpx.data, pkdpx.controls_flags)
+        except KaitaiStructError:
+            output_data = file.data
+
+        open(extract_path / str(i), "wb").write(output_data)
 
 
 if __name__ == "__main__":

--- a/tools/extract_pack.py
+++ b/tools/extract_pack.py
@@ -1,0 +1,25 @@
+"""A tool to extract sub-files from a PMD2 pack file."""
+
+from pathlib import Path
+
+import click
+from pmd2pack import Pmd2pack
+
+
+@click.command()
+@click.argument("pack_file", type=click.Path(exists=True, dir_okay=False))
+@click.argument("output_dir", type=click.Path(file_okay=False))
+def main(pack_file: str, output_dir: str) -> None:
+    pack = Pmd2pack.from_file(pack_file)
+
+    extract_folder = Path(pack_file).name + "_extract"
+    extract_path = Path(output_dir) / extract_folder
+    extract_path.mkdir(parents=True, exist_ok=True)
+
+    file: Pmd2pack.File
+    for i, file in enumerate(pack.files):
+        open(extract_path / str(i), "wb").write(file.data)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pkdpx.ksy
+++ b/tools/pkdpx.ksy
@@ -1,0 +1,16 @@
+meta:
+  id: pkdpx
+  endian: le
+  file-extension: pkdpx
+  
+seq:
+  - id: magic
+    contents: "PKDPX"
+  - id: length
+    type: u2
+  - id: controls_flags
+    size: 9
+  - id: decompressed_length
+    type: u4
+  - id: data
+    size: length - 20

--- a/tools/pkdpx.py
+++ b/tools/pkdpx.py
@@ -1,0 +1,26 @@
+# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+
+import kaitaistruct
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
+
+
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+
+class Pkdpx(KaitaiStruct):
+    def __init__(self, _io, _parent=None, _root=None):
+        self._io = _io
+        self._parent = _parent
+        self._root = _root if _root else self
+        self._read()
+
+    def _read(self):
+        self.magic = self._io.read_bytes(5)
+        if not self.magic == b"\x50\x4B\x44\x50\x58":
+            raise kaitaistruct.ValidationNotEqualError(b"\x50\x4B\x44\x50\x58", self.magic, self._io, u"/seq/0")
+        self.length = self._io.read_u2le()
+        self.controls_flags = self._io.read_bytes(9)
+        self.decompressed_length = self._io.read_u4le()
+        self.data = self._io.read_bytes((self.length - 20))
+
+

--- a/tools/pmd2pack.ksy
+++ b/tools/pmd2pack.ksy
@@ -1,0 +1,26 @@
+meta:
+  id: pmd2pack
+  endian: le
+  file-extension: bin
+    
+seq:
+  - id: buffer
+    type: u4
+  - id: file_count
+    type: u4
+  - id: files
+    type: file
+    repeat: expr
+    repeat-expr: file_count
+  
+types:
+  file:
+    seq:
+      - id: pointer
+        type: u4
+      - id: length
+        type: u4
+    instances:
+      data:
+        pos: pointer
+        size: length

--- a/tools/pmd2pack.py
+++ b/tools/pmd2pack.py
@@ -1,0 +1,47 @@
+# This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
+
+import kaitaistruct
+from kaitaistruct import BytesIO, KaitaiStream, KaitaiStruct
+
+if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
+
+class Pmd2pack(KaitaiStruct):
+    def __init__(self, _io, _parent=None, _root=None):
+        self._io = _io
+        self._parent = _parent
+        self._root = _root if _root else self
+        self._read()
+
+    def _read(self):
+        self.buffer = self._io.read_u4le()
+        self.file_count = self._io.read_u4le()
+        self.files = []
+        for i in range(self.file_count):
+            self.files.append(Pmd2pack.File(self._io, self, self._root))
+
+
+    class File(KaitaiStruct):
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._read()
+
+        def _read(self):
+            self.pointer = self._io.read_u4le()
+            self.length = self._io.read_u4le()
+
+        @property
+        def data(self):
+            if hasattr(self, '_m_data'):
+                return self._m_data
+
+            _pos = self._io.pos()
+            self._io.seek(self.pointer)
+            self._m_data = self._io.read_bytes(self.length)
+            self._io.seek(_pos)
+            return getattr(self, '_m_data', None)
+
+
+


### PR DESCRIPTION
The `MONSTER` and `BALANCE` folders contain [PMD2 pack files](https://projectpokemon.org/home/docs/mystery-dungeon-nds/pmd2-pack-file-format-r42/). These files contain sub-files, some of which use the [PKDPX format](https://projectpokemon.org/docs/mystery-dungeon-nds/pkdpx-file-format-r44/) — file data compressed with [PX compression](https://projectpokemon.org/docs/mystery-dungeon-nds/pmd2-px-compression-r45/). This PR adds a new CLI tool called `extract_pack.py`, which extracts these sub-files and decompresses them if necessary. Kaitai definitions have been written for the pack and PKDPX file formats and compiled into Kaitai parsers, which are used by the CLI tool.